### PR TITLE
Update PingsEndpoints.cs

### DIFF
--- a/src/DEPLOY.KeyCloak.API/Endpoints/v1/PingsEndpoints.cs
+++ b/src/DEPLOY.KeyCloak.API/Endpoints/v1/PingsEndpoints.cs
@@ -27,7 +27,7 @@ namespace DEPLOY.KeyCloak.API.Endpoints.v1
                 })
                 .WithOpenApi(operation => new(operation)
                 {
-                    OperationId = "get-ping-pong-test-v1",
+                    OperationId = "get-ping-pong-test",
 
                 })
             .Produces<string>(200);


### PR DESCRIPTION
This pull request includes a minor update to the `OperationId` in the `MapPingsEndpoints` method to improve consistency in naming.

* [`src/DEPLOY.KeyCloak.API/Endpoints/v1/PingsEndpoints.cs`](diffhunk://#diff-ebf4c30401099e00b51661221f001709c231c57564f0037a9e058a5620cf1c23L30-R30): Updated the `OperationId` in the `WithOpenApi` configuration from `"get-ping-pong-test-v1"` to `"get-ping-pong-test"`.